### PR TITLE
Fix typo in default value for outfile

### DIFF
--- a/src/main/java/com/akathist/maven/plugins/launch4j/Launch4jMojo.java
+++ b/src/main/java/com/akathist/maven/plugins/launch4j/Launch4jMojo.java
@@ -122,7 +122,7 @@ public class Launch4jMojo extends AbstractMojo {
      * The name of the executable you want launch4j to produce.
      * The path, if relative, is relative to the pom.xml.
      */
-    @Parameter(defaultValue = "${project.bluid.directory}/${project.artifactId}.exe")
+    @Parameter(defaultValue = "${project.build.directory}/${project.artifactId}.exe")
     private File outfile;
 
     /**


### PR DESCRIPTION
The outfile field had a typo in it's default value: 'bluid' instead of 'build'.
This made the launch4j goal fail unless there was an outfile specified in the configuration.