### PR TITLE
Added support for unwrapped jar

### DIFF
--- a/src/main/java/com/akathist/maven/plugins/launch4j/Launch4jMojo.java
+++ b/src/main/java/com/akathist/maven/plugins/launch4j/Launch4jMojo.java
@@ -357,7 +357,11 @@ public class Launch4jMojo extends AbstractMojo {
 
             c.setHeaderType(headerType);
             c.setOutfile(outfile);
-            c.setJar(getJar());
+
+            if(!dontWrapJar){
+            	c.setJar(getJar());
+            }
+
             c.setDontWrapJar(dontWrapJar);
             c.setErrTitle(errTitle);
             c.setDownloadUrl(downloadUrl);


### PR DESCRIPTION
The jar file must not be added to the launch4j config if dontWrapJar is
enabled. Otherwise it would result in a

net.sf.launch4j.BuilderException: Specify runtime path of the jar relative
to the executable.