### PR TITLE
Use the linux64 platform when run on 64-bit Linux.

### DIFF
--- a/src/main/java/com/akathist/maven/plugins/launch4j/Launch4jMojo.java
+++ b/src/main/java/com/akathist/maven/plugins/launch4j/Launch4jMojo.java
@@ -586,14 +586,21 @@ public class Launch4jMojo extends AbstractMojo {
     private Artifact chooseBinaryBits() throws MojoExecutionException {
         String plat;
         String os = System.getProperty("os.name");
+        String arch = System.getProperty("os.arch");
         getLog().debug("OS = " + os);
+        getLog().debug("Architecture = " + arch);
 
         // See here for possible values of os.name:
         // http://lopica.sourceforge.net/os.html
         if (os.startsWith("Windows")) {
             plat = "win32";
         } else if ("Linux".equals(os)) {
-            plat = "linux";
+            if ("amd64".equals(arch)) {
+                plat = "linux64";
+            }
+            else {
+                plat = "linux";
+            }
         } else if ("Solaris".equals(os) || "SunOS".equals(os)) {
             plat = "solaris";
         } else if ("Mac OS X".equals(os) || "Darwin".equals(os)) {


### PR DESCRIPTION
This allows the use of launch4j plugin when run on a 64-bit Linux with no 32-bit support, such as Windows Subsystem for Linux.

Upstream Launch4j project since 3.11 includes a set of 64-bit binaries for use on Linux.

This should address #4. While Linux on AMD64 usually includes support for running 32-bit executables some distributions don't. And some systems like WSL just won't entertain 32-bit on a 64-bit system.