### PR TITLE
Remove unused dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,17 +84,6 @@
             <artifactId>maven-project</artifactId>
             <version>2.2.1</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-plugin-descriptor</artifactId>
-            <version>2.2.1</version>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Hello, I've noticed that dependencies maven-plugin-descriptor and junit are declared in the pom. However, those dependencies are not used. Therefore, it makes sense to remove them.